### PR TITLE
Don't compile avx2 version on non x86 platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ NVCC ?= nvcc -std=c++11
 # end Flags from upstream
 
 REPO = https://github.com/aeternity/cuckoo.git
-COMMIT = 3fbc70bab20859e19dbc2341529ad44b4e7a0cef
+COMMIT = 7033a61400c2f7acab5764ffcae00c761541589d
 
 .PHONY: all
 all: $(EXECUTABLES)

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
 EXECUTABLES = \
 	mean29-generic \
-	mean29-avx2 \
 	lean29-generic \
-	lean29-avx2 \
 	mean15-generic \
 	lean15-generic
+
+ifeq ($(shell uname -m), x86_64)
+EXECUTABLES += \
+	mean29-avx2 \
+	lean29-avx2
+endif
 
 PRIVEXECS = $(addprefix $(PRIV)/, $(EXECUTABLES))
 


### PR DESCRIPTION
This change mirrors the changes in the parts of the cuckoo Makefile we have brought up to this level.

This PR is sponsored by the ACF